### PR TITLE
feat: US_46/InvisibleWallWithCamera

### DIFF
--- a/MarioGame/Source/Systems/CameraSystem.cs
+++ b/MarioGame/Source/Systems/CameraSystem.cs
@@ -48,6 +48,7 @@ namespace SuperMarioBros.Source.Systems
                             colliderCamera = new ColliderComponent(colliderComponent.collider.World, camera.Position.X , 100, new Rectangle(100, 100, 5, 1500), BodyType.Static);
                         }
                     }
+
                     camera.Transform = Matrix.CreateTranslation(new Vector3(-camera.Position, 0));
                 }
             }

--- a/MarioGame/Source/Systems/CameraSystem.cs
+++ b/MarioGame/Source/Systems/CameraSystem.cs
@@ -38,7 +38,6 @@ namespace SuperMarioBros.Source.Systems
                             MathHelper.Clamp(playerPosition.Position.X - camera.Viewport.Width / 2, 0, camera.WorldWidth - camera.Viewport.Width),
                             MathHelper.Clamp(playerPosition.Position.Y - camera.Viewport.Height / 2, 0, camera.WorldHeight - camera.Viewport.Height)
                         );
-
                         camera.LastXPosition = playerPosition.Position.X;
                         if (colliderCamera != null)
                         {
@@ -49,7 +48,6 @@ namespace SuperMarioBros.Source.Systems
                             colliderCamera = new ColliderComponent(colliderComponent.collider.World, camera.Position.X , 100, new Rectangle(100, 100, 5, 1500), BodyType.Static);
                         }
                     }
-
                     camera.Transform = Matrix.CreateTranslation(new Vector3(-camera.Position, 0));
                 }
             }

--- a/MarioGame/Source/Systems/CameraSystem.cs
+++ b/MarioGame/Source/Systems/CameraSystem.cs
@@ -5,11 +5,18 @@ using Microsoft.Xna.Framework;
 
 using SuperMarioBros.Source.Components;
 using SuperMarioBros.Source.Entities;
+using nkast.Aether.Physics2D.Dynamics;
+
+using SuperMarioBros.Utils;
+
+using AetherVector2 = nkast.Aether.Physics2D.Common.Vector2;
+
 
 namespace SuperMarioBros.Source.Systems
 {
     public class CameraSystem : BaseSystem
     {
+        private ColliderComponent colliderCamera { get; set; }
         public override void Update(GameTime gameTime, IEnumerable<Entity> entities)
         {
             var playerEntities = entities
@@ -21,6 +28,7 @@ namespace SuperMarioBros.Source.Systems
             {
                 var camera = playerEntity.GetComponent<CameraComponent>();
                 var playerPosition = playerEntity.GetComponent<PositionComponent>();
+                var colliderComponent = playerEntity.GetComponent<ColliderComponent>();
 
                 if (playerPosition != null && camera != null)
                 {
@@ -32,6 +40,14 @@ namespace SuperMarioBros.Source.Systems
                         );
 
                         camera.LastXPosition = playerPosition.Position.X;
+                        if (colliderCamera != null)
+                        {
+                            colliderCamera.collider.Position = new AetherVector2(camera.Position.X / Constants.pixelPerMeter, colliderCamera.collider.Position.Y);
+                        }
+                        else
+                        {
+                            colliderCamera = new ColliderComponent(colliderComponent.collider.World, camera.Position.X , 100, new Rectangle(100, 100, 5, 1500), BodyType.Static);
+                        }
                     }
 
                     camera.Transform = Matrix.CreateTranslation(new Vector3(-camera.Position, 0));


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->
We are looking for the camera to have a border that will be in line with the camera so that mario cannot move backwards and go out of the screen.

## Related Issue(s)
<!-- If this pull request resolves any GitHub issues, mention them here using GitHub's issue linking syntax (e.g., #123). -->

## Changes Made
<!-- Enumerate the main changes made by this pull request. -->

- [x] Modifications of the camera system.

## Screenshots (if applicable)
<!-- Include screenshots or GIFs to demonstrate visual changes, if relevant. -->

## Checklist
<!-- Mark tasks as complete by putting an "x" in the box. -->
<!-- For example: [x] Task 1 -->
<!-- If you're unsure about any task, don't hesitate to ask for clarification. -->

- [x] There are collisions with map objects and gravity to make it fall to the ground.
- [x] The wall must advance together with the camera, so that it is always present. 

code reviuw

@aguirrekarina 
@OropezaHugo 