### PR TITLE
feat: US_46/InvisibleWallWithCamera

### DIFF
--- a/MarioGame/Source/Systems/PlayerMovementSystem.cs
+++ b/MarioGame/Source/Systems/PlayerMovementSystem.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
-
+using nkast.Aether.Physics2D.Dynamics;
 using SuperMarioBros.Source.Components;
 using SuperMarioBros.Source.Entities;
 using SuperMarioBros.Source.Extensions;
@@ -14,7 +14,7 @@ namespace SuperMarioBros.Source.Systems
 {
     public class PlayerMovementSystem : BaseSystem
     {
-
+        private static ColliderComponent colliderCamera { get; set; }
         private bool keyboardJumpReleased = true;
         private bool gamepadJumpReleased = true;
 
@@ -28,6 +28,7 @@ namespace SuperMarioBros.Source.Systems
                 var movement = player.GetComponent<MovementComponent>();
                 var keyboardState = Keyboard.GetState();
                 var gamePadState = GamePad.GetState(PlayerIndex.One);
+                var camera = player.GetComponent<CameraComponent>();
                 if (keyboardState.IsKeyDown(Keys.Left) || gamePadState.DPad.Left == ButtonState.Pressed)
                 {
                     HandleLeftKey(collider, animation, movement);
@@ -42,6 +43,9 @@ namespace SuperMarioBros.Source.Systems
                 }
                 HandleUpKey(gamePadState, keyboardState, collider, animation, movement);
                 LimitSpeed(collider, collider.maxSpeed);
+
+                colliderCamera = new ColliderComponent(collider.collider.World, camera.Position.X+1f, 100, new Rectangle(100, 100, 10, 10), BodyType.Static);
+
             }
         }
 
@@ -59,9 +63,25 @@ namespace SuperMarioBros.Source.Systems
                 }
             }
             movement.Direction = MovementType.LEFT;
-            if (collider.collider.LinearVelocity.X > -collider.maxSpeed)
+            double positionX;
+
+            if (colliderCamera.collider.Position.X <= 0.0)
             {
-                collider.collider.ApplyForce(new AetherVector2(-collider.velocity, 0));
+                positionX = colliderCamera.collider.Position.X + 1.0f;
+            }
+            else
+            {
+                positionX = colliderCamera.collider.Position.X + 1.5f;
+
+            }
+
+            if (collider.collider.Position.X >= positionX )
+            {
+                movement.Direction = MovementType.LEFT;
+                if (collider.collider.LinearVelocity.X > -collider.maxSpeed)
+                {
+                    collider.collider.ApplyForce(new AetherVector2(-collider.velocity, 0));
+                }
             }
         }
 

--- a/MarioGame/Source/Systems/PlayerMovementSystem.cs
+++ b/MarioGame/Source/Systems/PlayerMovementSystem.cs
@@ -42,7 +42,8 @@ namespace SuperMarioBros.Source.Systems
                 {
                     HandleStop(collider, animation, movement);
                 }
-                HandleUpKey(gamePadState, keyboardState, collider, animation, movement);
+
+                if (gameTime != null) HandleUpKey(gamePadState, keyboardState, collider, animation, movement, gameTime);
                 LimitSpeed(collider, collider.maxSpeed);
                 CreateImvisibleWall(camera,collider);
             }
@@ -105,12 +106,20 @@ namespace SuperMarioBros.Source.Systems
             };
         }
 
-        private void HandleUpKey(GamePadState gamePadState, KeyboardState keyboardState, ColliderComponent collider, AnimationComponent animation, MovementComponent movement)
+        private void HandleUpKey(GamePadState gamePadState, KeyboardState keyboardState, ColliderComponent collider, AnimationComponent animation, MovementComponent movement,GameTime gameTime)
         {
-            if ((keyboardState.IsKeyDown(Keys.Z) && keyboardJumpReleased || gamePadState.Buttons.A == ButtonState.Pressed && gamepadJumpReleased) && !collider.isJumping())
+            if (collider == null || animation == null || movement == null || colliderCamera == null)
+            {
+                return;
+            }
+
+            bool jumpCondition = (keyboardState.IsKeyDown(Keys.Z) && keyboardJumpReleased) || (gamePadState.Buttons.A == ButtonState.Pressed && gamepadJumpReleased);
+
+            if (jumpCondition && !collider.isJumping())
             {
                 if (keyboardState.IsKeyDown(Keys.Z)) keyboardJumpReleased = false;
                 if (gamePadState.Buttons.A == ButtonState.Pressed) gamepadJumpReleased = false;
+
                 if (movement.Direction == MovementType.LEFT)
                 {
                     animation.Play(AnimationState.JUMPLEFT);
@@ -123,6 +132,7 @@ namespace SuperMarioBros.Source.Systems
                 }
                 collider.collider.ApplyLinearImpulse(new AetherVector2(0, -4.29f));
             }
+
             if (keyboardState.IsKeyUp(Keys.Z))
             {
                 keyboardJumpReleased = true;
@@ -130,6 +140,16 @@ namespace SuperMarioBros.Source.Systems
             if (gamePadState.Buttons.A == ButtonState.Released)
             {
                 gamepadJumpReleased = true;
+            }
+
+
+            if (collider.isJumping())
+            {
+                if (collider.collider.Position.X + collider.collider.LinearVelocity.X * (float)gameTime.ElapsedGameTime.TotalSeconds <= colliderCamera.collider.Position.X + 0.3f)
+                {
+                    collider.collider.LinearVelocity = new AetherVector2(1, collider.collider.LinearVelocity.Y);
+                    animation.Play(AnimationState.JUMPLEFT);
+                }
             }
         }
 

--- a/MarioGame/Source/Systems/PlayerMovementSystem.cs
+++ b/MarioGame/Source/Systems/PlayerMovementSystem.cs
@@ -46,11 +46,14 @@ namespace SuperMarioBros.Source.Systems
                 if (gameTime != null) HandleUpKey(gamePadState, keyboardState, collider, animation, movement, gameTime);
                 LimitSpeed(collider, collider.maxSpeed);
                 CreateImvisibleWall(camera,collider);
+
+
             }
         }
 
         private static void CreateImvisibleWall(CameraComponent camera,ColliderComponent collider)
         {
+
             if (colliderCamera != null)
             {
                 colliderCamera.collider.Position = new AetherVector2(camera.Position.X / GameConstants.pixelPerMeter, colliderCamera.collider.Position.Y);
@@ -63,6 +66,11 @@ namespace SuperMarioBros.Source.Systems
 
         private static void HandleLeftKey(ColliderComponent collider, AnimationComponent animation, MovementComponent movement)
         {
+            if (collider == null || animation == null || movement == null || colliderCamera == null)
+            {
+                return;
+            }
+
             if (!collider.isJumping())
             {
                 if (collider.collider.LinearVelocity.X > 0)
@@ -74,9 +82,13 @@ namespace SuperMarioBros.Source.Systems
                     animation.Play(AnimationState.WALKLEFT);
                 }
             }
-            movement.Direction = MovementType.LEFT;
 
-            if (collider.collider.Position.X >= colliderCamera.collider.Position.X + 1.5f )
+            float velocityThreshold = collider.maxSpeed * 0.5f;
+            bool isWithImpulse = Math.Abs(collider.collider.LinearVelocity.X) > velocityThreshold;
+
+            float limit = isWithImpulse ? 1.4f : 0.7f;
+
+            if (collider.collider.Position.X >= colliderCamera.collider.Position.X + limit)
             {
                 movement.Direction = MovementType.LEFT;
                 if (collider.collider.LinearVelocity.X > -collider.maxSpeed)
@@ -85,6 +97,7 @@ namespace SuperMarioBros.Source.Systems
                 }
             }
         }
+
 
         private static void HandleKeyRight(ColliderComponent collider, AnimationComponent animation, MovementComponent movement)
         {
@@ -147,7 +160,7 @@ namespace SuperMarioBros.Source.Systems
             {
                 if (collider.collider.Position.X + collider.collider.LinearVelocity.X * (float)gameTime.ElapsedGameTime.TotalSeconds <= colliderCamera.collider.Position.X + 0.3f)
                 {
-                    collider.collider.LinearVelocity = new AetherVector2(1, collider.collider.LinearVelocity.Y);
+                    collider.collider.LinearVelocity = new AetherVector2(0, collider.collider.LinearVelocity.Y);
                     animation.Play(AnimationState.JUMPLEFT);
                 }
             }

--- a/MarioGame/Source/Systems/PlayerMovementSystem.cs
+++ b/MarioGame/Source/Systems/PlayerMovementSystem.cs
@@ -7,6 +7,7 @@ using nkast.Aether.Physics2D.Dynamics;
 using SuperMarioBros.Source.Components;
 using SuperMarioBros.Source.Entities;
 using SuperMarioBros.Source.Extensions;
+using SuperMarioBros.Utils;
 using SuperMarioBros.Utils.DataStructures;
 
 using AetherVector2 = nkast.Aether.Physics2D.Common.Vector2;
@@ -43,9 +44,19 @@ namespace SuperMarioBros.Source.Systems
                 }
                 HandleUpKey(gamePadState, keyboardState, collider, animation, movement);
                 LimitSpeed(collider, collider.maxSpeed);
+                CreateImvisibleWall(camera,collider);
+            }
+        }
 
+        private static void CreateImvisibleWall(CameraComponent camera,ColliderComponent collider)
+        {
+            if (colliderCamera != null)
+            {
+                colliderCamera.collider.Position = new AetherVector2(camera.Position.X / GameConstants.pixelPerMeter, colliderCamera.collider.Position.Y);
+            }
+            else
+            {
                 colliderCamera = new ColliderComponent(collider.collider.World, camera.Position.X+1f, 100, new Rectangle(100, 100, 10, 10), BodyType.Static);
-
             }
         }
 
@@ -63,18 +74,8 @@ namespace SuperMarioBros.Source.Systems
                 }
             }
             movement.Direction = MovementType.LEFT;
-            double positionX;
 
-            if (colliderCamera.collider.Position.X <= 0.0)
-            {
-                positionX = colliderCamera.collider.Position.X + 1.0f;
-            }
-            else
-            {
-                positionX = colliderCamera.collider.Position.X + 1.5f;
-
-            }
-            if (collider.collider.Position.X >= positionX )
+            if (collider.collider.Position.X >= colliderCamera.collider.Position.X + 1.5f )
             {
                 movement.Direction = MovementType.LEFT;
                 if (collider.collider.LinearVelocity.X > -collider.maxSpeed)

--- a/MarioGame/Source/Systems/PlayerMovementSystem.cs
+++ b/MarioGame/Source/Systems/PlayerMovementSystem.cs
@@ -74,7 +74,6 @@ namespace SuperMarioBros.Source.Systems
                 positionX = colliderCamera.collider.Position.X + 1.5f;
 
             }
-
             if (collider.collider.Position.X >= positionX )
             {
                 movement.Direction = MovementType.LEFT;


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->

We are looking for the camera to have a border that will be in line with the camera so that mario cannot move backwards and go out of the screen.

## Related Issue(s)
<!-- If this pull request resolves any GitHub issues, mention them here using GitHub's issue linking syntax (e.g., #123). -->

## Changes Made
<!-- Enumerate the main changes made by this pull request. -->

- [x] Modifications of the PlayerMovementSystem.

## Screenshots (if applicable)
<!-- Include screenshots or GIFs to demonstrate visual changes, if relevant. -->

## Checklist
<!-- Mark tasks as complete by putting an "x" in the box. -->
<!-- For example: [x] Task 1 -->
<!-- If you're unsure about any task, don't hesitate to ask for clarification. -->

- [x]  There are collisions with map objects and gravity to make it fall to the ground.
- [x]  The wall must advance together with the camera, so that it is always present.

code reviuw

@aguirrekarina 
@OropezaHugo 
