### PR TITLE
fix: solve mario's death bugs

### DIFF
--- a/MarioGame/Source/Scenes/LevelScene.cs
+++ b/MarioGame/Source/Scenes/LevelScene.cs
@@ -370,7 +370,8 @@ namespace SuperMarioBros.Source.Scenes
             if (playerComponent != null && animationComponent != null && colliderComponent != null && playerComponent.IsAlive)
             {
                 playerComponent.IsAlive = false;
-                PlayerSystem.StartDeathAnimation(playerComponent, colliderComponent, 50);
+                PlayerSystem.StartDeathAnimation(playerComponent, colliderComponent, 10);
+
             }
         }
 

--- a/MarioGame/Source/Systems/PlayerSystem.cs
+++ b/MarioGame/Source/Systems/PlayerSystem.cs
@@ -214,6 +214,7 @@ namespace SuperMarioBros.Source.Systems
             playerComponent.DeathTimer = 0;
             playerComponent.statusMario = StatusMario.SmallMario;
             colliderComponent.RemoveCollider();
+            colliderComponent.collider.ResetDynamics();
             colliderComponent.collider.ApplyForce(new AetherVector2(0, -jumpForce));
             EventDispatcher.Instance.Dispatch(new SoundEffectEvent(SoundEffectType.PlayerLostLife));
         }

--- a/MarioGame/Source/Systems/PlayerSystem.cs
+++ b/MarioGame/Source/Systems/PlayerSystem.cs
@@ -215,7 +215,7 @@ namespace SuperMarioBros.Source.Systems
             playerComponent.statusMario = StatusMario.SmallMario;
             colliderComponent.RemoveCollider();
             colliderComponent.collider.ResetDynamics();
-            colliderComponent.collider.ApplyForce(new AetherVector2(0, -jumpForce));
+            colliderComponent.collider.LinearVelocity = new AetherVector2(0, -jumpForce/100);
             EventDispatcher.Instance.Dispatch(new SoundEffectEvent(SoundEffectType.PlayerLostLife));
         }
 
@@ -229,12 +229,12 @@ namespace SuperMarioBros.Source.Systems
             if (animationComponent == null) throw new ArgumentNullException(nameof(animationComponent));
             animationComponent.Play(AnimationState.DIE);
 
-            if (playerComponent.DeathTimer <= 1f)
+            if (playerComponent.DeathTimer <= 0.7f)
             {
                 colliderComponent.collider.ApplyForce(new AetherVector2(0, -22f));
 
             }
-            else if (playerComponent.DeathTimer > 1f && playerComponent.DeathTimer <= 2f)
+            else if (playerComponent.DeathTimer > 0.7f && playerComponent.DeathTimer <= 2f)
             {
                 colliderComponent.collider.ApplyForce(new AetherVector2(0, 22f));
             }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->

## Related Issue(s)
<!-- If this pull request resolves any GitHub issues, mention them here using GitHub's issue linking syntax (e.g., #123). -->
![image](https://github.com/user-attachments/assets/bf95fde8-14d9-47ec-8212-b62127014780)

## Changes Made
<!-- Enumerate the main changes made by this pull request. -->

- [x] reset dynamics on Mario's death animation

## Screenshots (if applicable)
<!-- Include screenshots or GIFs to demonstrate visual changes, if relevant. -->

## Checklist
<!-- Mark tasks as complete by putting an "x" in the box. -->
<!-- For example: [x] Task 1 -->
<!-- If you're unsure about any task, don't hesitate to ask for clarification. -->

- [x] I have reviewed my own code changes.
- [x] I have tested these changes locally.
- [x] My code follows the project's coding style guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added appropriate labels to this pull request.

@GastonGutierrezC 
@JuanPabloArequipa 

